### PR TITLE
Dependency update: irap/core-libs to v1.3.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "ext-mysqli": "*"
     },
     "require-dev": {
-        "irap/core-libs": "1.2.*"
+        "irap/core-libs": "1.3.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Note - this dependency is only relevant on "dev" (it's in the require-dev part of the composer config), but updating it now because any project that uses it on php8.4 will need to have this update.